### PR TITLE
ユーザshowページにタブを作成する。

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,12 @@ class UsersController < ApplicationController
   def new
   end
 
+  def index
+    @users = User.all
+  end
+
   def show
-    @user = current_user
+    @user = User.find(params[:id])
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = current_user
   end
 
   def edit

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
         <nav>
             <% if user_signed_in? %>
               <strong><%= link_to current_user.name, root_url %></strong>
+              <%= link_to 'show', user_path(current_user) %>
               <%= link_to 'プロフィール', edit_user_path(current_user) %>
               <%= link_to 'アカウント管理', edit_user_registration_path %>
               <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
         <nav>
             <% if user_signed_in? %>
               <strong><%= link_to current_user.name, root_url %></strong>
-              <%= link_to 'show', user_path(current_user) %>
+              <%= link_to 'index', users_path %>
               <%= link_to 'プロフィール', edit_user_path(current_user) %>
               <%= link_to 'アカウント管理', edit_user_registration_path %>
               <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>

--- a/app/views/users/_current_user_edit.html.erb
+++ b/app/views/users/_current_user_edit.html.erb
@@ -1,0 +1,43 @@
+<p>
+<%= link_to (image_tag url_for(@user.avatar.variant(resize: "100x100>"))), "#", data: {toggle: "modal", target: "#userAvatarModal"} %>
+<%= render partial: 'users/edit_form/avatar' %>
+</p>
+<p><%= @user.name %></p>
+
+
+<p>
+<%= link_to (text_area_tag '', @user.target_comment, readonly: true, placeholder: "具体的な目標を記入しよう！"), "#", data: {toggle: "modal", target: "#userTargetCommentModal"} %>
+<%= render partial: 'users/edit_form/target_comment' %>
+</p>
+
+<%# add following link %>
+<%# add follower link %>
+<%# add book link %>
+
+<p>自己紹介 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userIntroductionModal"}%></p>
+<%= render partial: 'users/edit_form/introduction' %>
+<p><%= @user.introduction %></p>
+
+<p>達成目標 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userTargetModal"}%></p>
+<%= render partial: 'users/edit_form/target' %>
+<p><%= @user.target %></p>
+
+<p>
+<% if @user.target == "大学受験合格" %>
+<%= render partial: 'users/edit_form/my_choice_university' %>
+<% end %>
+</p>
+<p>
+<%= @user.my_choice_university %>
+</p>
+
+
+<p>基本情報 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userBasicInformationModal"}%></p>
+<%= render partial: 'users/edit_form/basic_information' %>
+<p>ユーザ名 <%= @user.name %></p>
+<p>性別 <%= @user.gender %></p>
+<p>年齢 <%= @user.age %></p>
+<p>住まい <%= @user.live %></p>
+<p>職業 <%= @user.job %></p>
+
+<%= javascript_pack_tag 'users/edit' %>

--- a/app/views/users/_not_current_user_edit.html.erb
+++ b/app/views/users/_not_current_user_edit.html.erb
@@ -1,0 +1,38 @@
+<p>
+<%= image_tag url_for(@user.avatar.variant(resize: "100x100>")) %>
+</p>
+<p><%= @user.name %></p>
+
+
+<p>
+<%= text_area_tag '', @user.target_comment, disabled: true, placeholder: "具体的な目標を記入しよう！" %>
+</p>
+
+<%# add following link %>
+<%# add follower link %>
+<%# add book link %>
+
+<p>自己紹介</p>
+<p><%= @user.introduction %></p>
+
+<p>達成目標</p>
+<p><%= @user.target %></p>
+
+<p>
+<% if @user.target == "大学受験合格" %>
+<%= render partial: 'users/edit_form/my_choice_university' %>
+<% end %>
+</p>
+<p>
+<%= @user.my_choice_university %>
+</p>
+
+
+<p>基本情報</p>
+<p>ユーザ名 <%= @user.name %></p>
+<p>性別 <%= @user.gender %></p>
+<p>年齢 <%= @user.age %></p>
+<p>住まい <%= @user.live %></p>
+<p>職業 <%= @user.job %></p>
+
+<%= javascript_pack_tag 'users/edit' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,46 +1,9 @@
-<%= javascript_pack_tag 'users/edit' %>
 <h1>Users#edit</h1>
 <p>Find me in app/views/users/edit.html.erb</p>
 
 <p>プロフィール</p>
-<p>
-<%= link_to (image_tag url_for(@user.avatar.variant(resize: "100x100>"))), "#", data: {toggle: "modal", target: "#userAvatarModal"} %>
-<%= render partial: 'users/edit_form/avatar' %>
-</p>
-<p><%= @user.name %></p>
-
-
-<p>
-<%= link_to (text_area_tag '', @user.target_comment, readonly: true, placeholder: "具体的な目標を記入しよう！"), "#", data: {toggle: "modal", target: "#userTargetCommentModal"} %>
-<%= render partial: 'users/edit_form/target_comment' %>
-</p>
-
-<%# add following link %>
-<%# add follower link %>
-<%# add book link %>
-
-<p>自己紹介 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userIntroductionModal"}%></p>
-<%= render partial: 'users/edit_form/introduction' %>
-<p><%= @user.introduction %></p>
-
-<p>達成目標 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userTargetModal"}%></p>
-<%= render partial: 'users/edit_form/target' %>
-<p><%= @user.target %></p>
-
-<p>
-<% if @user.target == "大学受験合格" %>
-<%= render partial: 'users/edit_form/my_choice_university' %>
+<% unless current_user == @user %>
+  <%= render partial: 'users/not_current_user_edit' %>
+<% else %>
+  <%= render partial: 'users/current_user_edit' %>
 <% end %>
-</p>
-<p>
-<%= @user.my_choice_university %>
-</p>
-
-
-<p>基本情報 <%= link_to "編集", "#", data: {toggle: "modal", target: "#userBasicInformationModal"}%></p>
-<%= render partial: 'users/edit_form/basic_information' %>
-<p>ユーザ名 <%= @user.name %></p>
-<p>性別 <%= @user.gender %></p>
-<p>年齢 <%= @user.age %></p>
-<p>住まい <%= @user.live %></p>
-<p>職業 <%= @user.job %></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,7 @@
+<% @users.each do |user| %>
+  <p>
+    <td><%= user.name %></td>
+    <td><%= link_to 'Show', user %></td>
+    <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+  </p>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,19 @@
 <h1>Users#show</h1>
 <p>Find me in app/views/users/show.html.erb</p>
+
+<div class="row">
+  <div class="col-3">
+    <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+      <a class="nav-link" id="v-pills-profile-tab" data-toggle="pill" href="#v-pills-profile" role="tab" aria-controls="v-pills-profile" aria-selected="false">プロフィール</a>
+      <a class="nav-link" id="v-pills-book-tab" data-toggle="pill" href="#v-pills-book" role="tab" aria-controls="v-pills-book" aria-selected="false">教材</a>
+      <a class="nav-link active" id="v-pills-report-tab" data-toggle="pill" href="#v-pills-report" role="tab" aria-controls="v-pills-report" aria-selected="true">レポート</a>
+    </div>
+  </div>
+  <div class="col-9">
+    <div class="tab-content" id="v-pills-tabContent">
+      <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab"><%= render template: "users/edit" %></div>
+      <div class="tab-pane fade" id="v-pills-book" role="tabpanel" aria-labelledby="v-pills-book-tab">...</div>
+      <div class="tab-pane fade show active" id="v-pills-report" role="tabpanel" aria-labelledby="v-pills-report-tab">...</div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<h1>Users#show</h1>
+<h1>Users#show@<%= @user.name %></h1>
 <p>Find me in app/views/users/show.html.erb</p>
 
 <div class="row">
@@ -11,7 +11,13 @@
   </div>
   <div class="col-9">
     <div class="tab-content" id="v-pills-tabContent">
-      <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab"><%= render template: "users/edit" %></div>
+      <div class="tab-pane fade" id="v-pills-profile" role="tabpanel" aria-labelledby="v-pills-profile-tab">
+        <% unless current_user == @user %>
+          <%= render partial: 'users/not_current_user_edit' %>
+        <% else %>
+          <%= render template: "users/edit" %>
+        <% end %>
+      </div>
       <div class="tab-pane fade" id="v-pills-book" role="tabpanel" aria-labelledby="v-pills-book-tab">...</div>
       <div class="tab-pane fade show active" id="v-pills-report" role="tabpanel" aria-labelledby="v-pills-report-tab">...</div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'home#top'
   get 'home/home'
-  resources :users, except: [:index, :destroy]
+  resources :users
 end


### PR DESCRIPTION
close #20 
* 目的
ユーザshowページに、プロフィール、教材、レポート、３つのタブを作成。
ユーザページでページ遷移なしで上の３つの情報を見れるようにする。
* 達成条件
プロフィールタブ、教材タブ、レポートタブの作成。
プロフィールタブを押すと、ユーザのプロフィールページが表示されるようにする。
プロフィールページは現状誰でも編集できるようになっているため他のユーザのプロフィールは編集できないようにする。
* 実装の概要
ブートストラップを使ってタブを作成する。
* スケジュール
7/30